### PR TITLE
Release version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,34 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field).
 
 ## [Unreleased]
+
+## [0.2.1] - 2021-10-13
+
 ### Added
+
 - Add test jobs for basic encode/decode with and without check mode
 - New automated release system based on monero-rs/workflows
 - Documentation in README
 
 ### Changed
+
 - Update `base58-monero` to `0.3.1`
 - Update `futures-util` to `0.3.17`
 - Update `async-stream` to `0.3.2`
 
 ## [0.2.0] - 2021-04-30
+
 ### Added
+
 - Add `dependabot` and switch to GitHub Actions for the CI
 
 ### Changed
+
 - Update `base58-monero` to `0.3.0`
 - Update `tokio` to `1`
 - Rename project from `base58m-rs` to `base58m`
@@ -27,17 +36,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve documentation
 
 ### Fixed
+
 - Clap now uses the `crate_version!()` macro to display the binary version
 
 ## [0.1.1] - 2020-01-16
+
 ### Changed
+
 - Documentation and file tracking for crates.io releases
 
 ## [0.1.0] - 2020-01-09
+
 ### Added
+
 - `base58m` binary with support for encoding/decoding Monero base58 data with checksum support
 
-[Unreleased]: https://github.com/monero-rs/base58m/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/monero-rs/base58m/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/monero-rs/base58m/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/monero-rs/base58m/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/monero-rs/base58m/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/monero-rs/base58m/compare/1909d92fd48441c88e758c00f18c5aad23b0ac39...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name = "base58m"
-description = "base64-like binary with support for encoding/decoding Monero base58 strings."
-keywords = ["binary", "monero", "base58", "base58-check"]
-version = "0.2.0"
-authors = ["h4sh3d <h4sh3d@protonmail.com>"]
-license = "MIT"
+version = "0.2.1"
+authors = [ "h4sh3d <h4sh3d@protonmail.com>" ]
+edition = "2018"
 homepage = "https://github.com/monero-rs/base58m"
-repository = "https://github.com/monero-rs/base58m"
-readme = "README.md"
 include = [
     "src/*",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
 ]
-
-edition = "2018"
+keywords = [ "binary", "monero", "base58", "base58-check" ]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/monero-rs/base58m"
+description = "base64-like binary with support for encoding/decoding Monero base58 strings."
 
 [dependencies]
-clap = "2.33.0"
-base58-monero = "0.3.1"
-tokio = { version = "1", features = ["fs", "rt", "rt-multi-thread", "macros", "io-std", "io-util"] }
-futures-util = "0.3.17"
 async-stream = "0.3.2"
+base58-monero = "0.3.1"
+clap = "2.33.0"
+futures-util = "0.3.17"
 thiserror = "1"
+tokio = { version = "1", features = [ "fs", "rt", "rt-multi-thread", "macros", "io-std", "io-util" ] }


### PR DESCRIPTION
Hi @h4sh3d!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/monero-rs/base58m/actions/runs/1338134545.
I've updated the changelog and bumped the versions in the manifest files in this commit: f966f5e8b0548ae81bc435c9eb190d4d9b54b0e4.

Merging this PR will create a GitHub release and publish the library to crates.io!