### PR TITLE
Bump base58-monero from 0.3.1 to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump base58-monero from `0.3.1` to `0.3.2` ([#34](https://github.com/monero-rs/base58m/pull/34))
 - Bump tokio from `1.12.0` to `1.13.0` ([#30](https://github.com/monero-rs/base58m/pull/30))
 
 ## [0.2.1] - 2021-10-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base58-monero"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df741a56140a4d26932fde3bd69ce8abec7f50d238f8c16351caa789a6d8fe9"
+checksum = "935c90240f9b7749c80746bf88ad9cb346f34b01ee30ad4d566dfdecd6e3cc6a"
 dependencies = [
  "async-stream",
  "futures-util",


### PR DESCRIPTION
Update to latest release that fixes input validation.