### PR TITLE
ci: add cache for build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: Swatinem/rust-cache@v2.7.0
+
     - name: Install Rust ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1.0.7
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cache for build jobs in CI
+
 ## [1.0.1] - 2023-01-02
 
 ### Changed


### PR DESCRIPTION
This will help speeding up build tests when merging a train of updates